### PR TITLE
docs: update docs, include a license and remove cross env

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,5 @@
 NODE_PATH=src
+PORT=8000
 REACT_APP_URL=http://localhost:3000/
 REACT_APP_NAME=Boilerplate
 REACT_APP_PROD_API=

--- a/.env.development.template
+++ b/.env.development.template
@@ -1,3 +1,4 @@
+PORT=8000
 NODE_PATH=src
 REACT_APP_URL=http://localhost:3000/
 REACT_APP_NAME=Boilerplate

--- a/.env.production.template
+++ b/.env.production.template
@@ -1,3 +1,4 @@
+PORT=8000
 NODE_PATH=src
 REACT_APP_URL=http://localhost:3000/
 REACT_APP_NAME=Boilerplate

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,9 @@
+The MIT License (MIT)
+
+Copyright (c) 2020 Smakosh
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # CRA boilerplate
 
+## TypeScript version
+
 > [TypScript version](https://github.com/smakosh/CRA-boilerplate/tree/typescript)
+
+## Getting started
 
 1- Clone the repository
 
@@ -22,6 +26,8 @@ git clone git@github.com:smakosh/CRA-boilerplate.git
 cp .env.development.template .env
 ```
 
+## Installation and kickstart
+
 4- Install dependencies using Yarn
 
 ```bash
@@ -33,3 +39,18 @@ yarn
 ```bash
 yarn start
 ```
+
+## Features
+
+- Uses a feature based file structure
+- Context API used effectively following [Kent C. Dodds](https://kentcdodds.com/blog/how-to-use-react-context-effectively/)'s article
+- Reusable logic with React hooks
+- UI elements separated from the features, so that you can push them as an UI library on NPM in the future as your project grow and you start to export features as their standalone apps
+- Authentication already built in
+- Code splitting of your Authenticated/Unauthenticated routes using Supense and React.lazy
+- Helpers functions
+- SEO component ready and configured for you
+
+## License
+
+This project is licensed under the MIT License - see the [LICENSE.md](LICENSE.md) file for more details

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "yup": "^0.28.3"
   },
   "scripts": {
-    "start": "cross-env PORT=8000 react-scripts start",
+    "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
@@ -45,7 +45,6 @@
     ]
   },
   "devDependencies": {
-    "babel-plugin-macros": "^2.8.0",
-    "cross-env": "^7.0.2"
+    "babel-plugin-macros": "^2.8.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4047,14 +4047,7 @@ create-react-context@^0.3.0:
     gud "^1.0.0"
     warning "^4.0.3"
 
-cross-env@^7.0.2:
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.2.tgz#bd5ed31339a93a3418ac4f3ca9ca3403082ae5f9"
-  integrity sha512-KZP/bMEOJEDCkDQAyRhu3RL2ZO/SUVrxQVI0G3YEQ+OLbRA3c6zgixe8Mq8a/z7+HKlNEjo8oiLUs8iRijY2Rw==
-  dependencies:
-    cross-spawn "^7.0.1"
-
-cross-spawn@7.0.3, cross-spawn@^7.0.0, cross-spawn@^7.0.1, cross-spawn@^7.0.2:
+cross-spawn@7.0.3, cross-spawn@^7.0.0, cross-spawn@^7.0.2:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==


### PR DESCRIPTION
## What's new?
- Update docs
- Include an MIT license
- Remove cross-env and depend on a `PORT` env var as recommended by the official docs of CRA.

## Fixes
https://github.com/smakosh/CRA-boilerplate/issues/12